### PR TITLE
Core: Authentic Object/Item/Npc/Player culling

### DIFF
--- a/client/src/rsc/mudclient.java
+++ b/client/src/rsc/mudclient.java
@@ -10522,14 +10522,14 @@ public final class mudclient implements Runnable {
 
 					while (length * 8 > this.packetsIncoming.getBitHead() - -24) {
 						int var9 = this.packetsIncoming.getBitMask(11);
-						int var10 = this.packetsIncoming.getBitMask(5);
-						if (var10 > 15) {
-							var10 -= 32;
+						int var10 = this.packetsIncoming.getBitMask(6);
+						if (var10 > 31) {
+							var10 -= 64;
 						}
 
-						int var11 = this.packetsIncoming.getBitMask(5);
-						if (var11 > 15) {
-							var11 -= 32;
+						int var11 = this.packetsIncoming.getBitMask(6);
+						if (var11 > 31) {
+							var11 -= 64;
 						}
 
 						direction = this.packetsIncoming.getBitMask(4);
@@ -10811,16 +10811,14 @@ public final class mudclient implements Runnable {
 
 								while (this.packetsIncoming.getBitHead() - -34 < length * 8) {
 									var19 = this.packetsIncoming.getBitMask(12);
-									int var6 = this.packetsIncoming.getBitMask(5);
-									if (var6 > 15) {
-										var6 -= 32;
+									int var6 = this.packetsIncoming.getBitMask(6);
+									if (var6 > 31) {
+										var6 -= 64;
 									}
-
-									int var7 = this.packetsIncoming.getBitMask(5);
-									if (var7 > 15) {
-										var7 -= 32;
+									int var7 = this.packetsIncoming.getBitMask(6);
+									if (var7 > 31) {
+										var7 -= 64;
 									}
-
 									dir = this.packetsIncoming.getBitMask(4);
 									var9 = 64 + (var6 + this.playerLocalX) * this.tileSize;
 									var10 = (var7 + this.playerLocalZ) * this.tileSize - -64;

--- a/server/free.conf
+++ b/server/free.conf
@@ -23,6 +23,7 @@
 	<entry key="wilderness_boost">0</entry>
 	<entry key="skull_boost">0</entry>
 	<entry key="double_exp">false</entry>
+	<entry key="view_distance">2</entry>
 	<entry key="bank_size">192</entry>
 	<entry key="spawn_auction_npcs">false</entry>
 	<entry key="spawn_iron_man_npcs">false</entry>

--- a/server/members.conf
+++ b/server/members.conf
@@ -23,6 +23,7 @@
 	<entry key="wilderness_boost">0</entry>
 	<entry key="skull_boost">0</entry>
 	<entry key="double_exp">false</entry>
+	<entry key="view_distance">2</entry>
 	<entry key="bank_size">192</entry>
 	<entry key="spawn_auction_npcs">false</entry>
 	<entry key="spawn_iron_man_npcs">false</entry>

--- a/server/src/com/openrsc/server/Constants.java
+++ b/server/src/com/openrsc/server/Constants.java
@@ -94,6 +94,10 @@ public final class Constants {
 		 */
 		public static double SKULL_BOOST = 0;
 		/**
+		 * Player view distance
+		 */
+		public static int VIEW_DISTANCE = 2;
+		/**
 		 * A message players will receive upon login
 		 */
 		public static String MOTD = "Welcome to " + SERVER_NAME + "!";
@@ -186,6 +190,7 @@ public final class Constants {
 			MYSQL_TABLE_PREFIX = props.getProperty("mysql_table_prefix");
 			MYSQL_HOST = props.getProperty("mysql_host");
 			HMAC_PRIVATE_KEY = props.getProperty("HMAC_PRIVATE_KEY");
+			VIEW_DISTANCE = Integer.parseInt(props.getProperty("view_distance"));
 
 			// Game confs
 			WORLD_NUMBER = Integer.parseInt(props.getProperty("world_number"));
@@ -231,6 +236,10 @@ public final class Constants {
 			WANT_WOODCUTTING_GUILD = Boolean.parseBoolean(props.getProperty("want_woodcutting_guild"));
 
 			START_TIME = System.currentTimeMillis();
+
+			// Make sure config doesn't exceed max values
+			if (VIEW_DISTANCE > 4)
+				VIEW_DISTANCE = 4;
 		}
 	}
 

--- a/server/src/com/openrsc/server/GameStateUpdater.java
+++ b/server/src/com/openrsc/server/GameStateUpdater.java
@@ -257,15 +257,15 @@ public final class GameStateUpdater {
 		for (Npc newNPC : playerToUpdate.getViewArea().getNpcsInView()) {
 			if (playerToUpdate.getLocalNpcs().contains(newNPC) || newNPC.equals(playerToUpdate) || newNPC.isRemoved()
 					|| newNPC.getID() == 194 && !playerToUpdate.getCache().hasKey("ned_hired")
-					|| !playerToUpdate.withinRange(newNPC, 15)) {
+					|| !playerToUpdate.withinRange(newNPC, (Constants.GameServer.VIEW_DISTANCE * 8) - 1)) {
 				continue;
 			} else if (playerToUpdate.getLocalNpcs().size() >= 255) {
 				break;
 			}
 			byte[] offsets = DataConversions.getMobPositionOffsets(newNPC.getLocation(), playerToUpdate.getLocation());
 			packet.writeBits(newNPC.getIndex(), 12);
-			packet.writeBits(offsets[0], 5);
-			packet.writeBits(offsets[1], 5);
+			packet.writeBits(offsets[0], 6);
+			packet.writeBits(offsets[1], 6);
 			packet.writeBits(newNPC.getSprite(), 4);
 			packet.writeBits(newNPC.getID(), 10);
 
@@ -324,8 +324,8 @@ public final class GameStateUpdater {
 				byte[] offsets = DataConversions.getMobPositionOffsets(otherPlayer.getLocation(),
 						playerToUpdate.getLocation());
 				positionBuilder.writeBits(otherPlayer.getIndex(), 11);
-				positionBuilder.writeBits(offsets[0], 5);
-				positionBuilder.writeBits(offsets[1], 5);
+				positionBuilder.writeBits(offsets[0], 6);
+				positionBuilder.writeBits(offsets[1], 6);
 				positionBuilder.writeBits(otherPlayer.getSprite(), 4);
 				playerToUpdate.getLocalPlayers().add(otherPlayer);
 				if (playerToUpdate.getLocalPlayers().size() >= 255) {
@@ -530,9 +530,12 @@ public final class GameStateUpdater {
 		boolean changed = false;
 		PacketBuilder packet = new PacketBuilder();
 		packet.setID(48);
+		// TODO: This is not handled correctly.
+		//       According to RSC+ replays, the server never tells the client to unload objects until
+		//       a region is unloaded. It then instructs the client to only unload the region.
 		for (Iterator<GameObject> it$ = playerToUpdate.getLocalGameObjects().iterator(); it$.hasNext();) {
 			GameObject o = it$.next();
-			if (!playerToUpdate.withinRange(o) || o.isRemoved() || !o.isVisibleTo(playerToUpdate)) {
+			if (!playerToUpdate.withinGridRange(o) || o.isRemoved() || !o.isVisibleTo(playerToUpdate)) {
 				int offsetX = o.getX() - playerToUpdate.getX();
 				int offsetY = o.getY() - playerToUpdate.getY();
 				//If the object is close enough we can use regular way to remove:	
@@ -553,7 +556,7 @@ public final class GameStateUpdater {
 		}
 
 		for (GameObject newObject : playerToUpdate.getViewArea().getGameObjectsInView()) {
-			if (!playerToUpdate.withinRange(newObject) || newObject.isRemoved()
+			if (!playerToUpdate.withinGridRange(newObject) || newObject.isRemoved()
 					|| !newObject.isVisibleTo(playerToUpdate) || newObject.getType() != 0
 					|| playerToUpdate.getLocalGameObjects().contains(newObject)) {
 				continue;
@@ -580,7 +583,7 @@ public final class GameStateUpdater {
 			int offsetX = (groundItem.getX() - playerToUpdate.getX());
 			int offsetY = (groundItem.getY() - playerToUpdate.getY());
 
-			if(!playerToUpdate.withinRange(groundItem)) {
+			if(!playerToUpdate.withinGridRange(groundItem)) {
 				if(offsetX > -128 && offsetY > -128 && offsetX < 128 && offsetY < 128) {
 					packet.writeByte(255);
 					packet.writeByte(offsetX);
@@ -605,7 +608,7 @@ public final class GameStateUpdater {
 		}
 
 		for (GroundItem groundItem : playerToUpdate.getViewArea().getItemsInView()) {
-			if (!playerToUpdate.withinRange(groundItem) || groundItem.isRemoved()
+			if (!playerToUpdate.withinGridRange(groundItem) || groundItem.isRemoved()
 					|| !groundItem.visibleTo(playerToUpdate)
 					|| playerToUpdate.getLocalGroundItems().contains(groundItem)) {
 				continue;
@@ -630,7 +633,7 @@ public final class GameStateUpdater {
 
 		for (Iterator<GameObject> it$ = playerToUpdate.getLocalWallObjects().iterator(); it$.hasNext();) {
 			GameObject o = it$.next();
-			if (!playerToUpdate.withinRange(o) || (o.isRemoved() || !o.isVisibleTo(playerToUpdate))) {
+			if (!playerToUpdate.withinGridRange(o) || (o.isRemoved() || !o.isVisibleTo(playerToUpdate))) {
 				int offsetX = o.getX() - playerToUpdate.getX();
 				int offsetY = o.getY() - playerToUpdate.getY();
 				if(offsetX > -128 && offsetY > -128 && offsetX < 128 && offsetY < 128) {
@@ -648,7 +651,7 @@ public final class GameStateUpdater {
 			}
 		}
 		for (GameObject newObject : playerToUpdate.getViewArea().getGameObjectsInView()) {
-			if (!playerToUpdate.withinRange(newObject) || newObject.isRemoved()
+			if (!playerToUpdate.withinGridRange(newObject) || newObject.isRemoved()
 					|| !newObject.isVisibleTo(playerToUpdate) || newObject.getType() != 1
 					|| playerToUpdate.getLocalWallObjects().contains(newObject)) {
 				continue;

--- a/server/src/com/openrsc/server/Server.java
+++ b/server/src/com/openrsc/server/Server.java
@@ -88,6 +88,7 @@ public final class Server implements Runnable {
 			LOGGER.info("\t Wilderness Experience Boost: {}", box(Constants.GameServer.WILDERNESS_BOOST));
 			LOGGER.info("\t Skull Experience Boost: {}", box(Constants.GameServer.SKULL_BOOST)); 
 			LOGGER.info("\t Double experience: " + (Constants.GameServer.IS_DOUBLE_EXP ? "Enabled" : "Disabled")); 
+			LOGGER.info("\t View Distance: {}", box(Constants.GameServer.VIEW_DISTANCE));
 		}
 		if(server == null) {
 			server = new Server();

--- a/server/src/com/openrsc/server/model/Point.java
+++ b/server/src/com/openrsc/server/model/Point.java
@@ -80,6 +80,14 @@ public class Point {
 				&& yDiff >= -radius;
 	}
 
+	public final boolean withinGridRange(Point p, int radius) {
+		// Snap coordinates to an 8x8 grid
+		// radius is compared in multiples of 8
+		final int xDiff = (this.x >> 3) - (p.x >> 3);
+		final int yDiff = (this.y >> 3) - (p.y >> 3);
+		return xDiff <= radius && xDiff >= -radius && yDiff <= radius && yDiff >= -radius;
+	}
+
 	public final int getX() {
 		return x;
 	}

--- a/server/src/com/openrsc/server/model/entity/Mob.java
+++ b/server/src/com/openrsc/server/model/entity/Mob.java
@@ -6,6 +6,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import com.openrsc.server.Constants;
 import com.openrsc.server.Server;
 import com.openrsc.server.event.DelayedEvent;
 import com.openrsc.server.event.rsc.impl.PoisonEvent;
@@ -653,9 +654,14 @@ public abstract class Mob extends Entity {
 
 	public boolean withinRange(Entity e) {
 		if (e != null) {
-			int xDiff = getLocation().getX() - e.getLocation().getX();
-			int yDiff = getLocation().getY() - e.getLocation().getY();
-			return xDiff <= 15 && xDiff >= -15 && yDiff <= 15 && yDiff >= -15;
+			return getLocation().withinRange(e.getLocation(), Constants.GameServer.VIEW_DISTANCE * 8);
+		}
+		return false;
+	}
+
+	public boolean withinGridRange(Entity e) {
+		if (e != null) {
+			return getLocation().withinGridRange(e.getLocation(), Constants.GameServer.VIEW_DISTANCE);
 		}
 		return false;
 	}

--- a/server/src/com/openrsc/server/model/world/region/RegionManager.java
+++ b/server/src/com/openrsc/server/model/world/region/RegionManager.java
@@ -2,6 +2,7 @@ package com.openrsc.server.model.world.region;
 
 import java.util.Collection;
 import java.util.LinkedHashSet;
+import com.openrsc.server.Constants;
 import com.openrsc.server.model.Point;
 import com.openrsc.server.model.entity.Entity;
 import com.openrsc.server.model.entity.GameObject;
@@ -71,7 +72,7 @@ public class RegionManager {
 		LinkedHashSet<GameObject> localObjects = new LinkedHashSet<GameObject>();
 		for (Region region : getSurroundingRegions(entity.getLocation())) {
 			for (GameObject o : region.getGameObjects()) {
-				if (o.getLocation().withinRange(entity.getLocation(), 15)) {
+				if (o.getLocation().withinGridRange(entity.getLocation(), Constants.GameServer.VIEW_DISTANCE)) {
 					localObjects.add(o);
 				}
 			}
@@ -83,7 +84,7 @@ public class RegionManager {
 		LinkedHashSet<GroundItem> localItems = new LinkedHashSet<GroundItem>();
 		for (Region region : getSurroundingRegions(entity.getLocation())) {
 			for (GroundItem o : region.getGroundItems()) {
-				if (o.getLocation().withinRange(entity.getLocation(), 15)) {
+				if (o.getLocation().withinGridRange(entity.getLocation(), Constants.GameServer.VIEW_DISTANCE)) {
 					localItems.add(o);
 				}
 			}

--- a/server/src/com/openrsc/server/util/rsc/DataConversions.java
+++ b/server/src/com/openrsc/server/util/rsc/DataConversions.java
@@ -311,7 +311,7 @@ public final class DataConversions {
 	private static byte getMobCoordOffset(int coord1, int coord2) {
 		byte offset = (byte) (coord1 - coord2);
 		if (offset < 0) {
-			offset += 32;
+			offset += 64;
 		}
 		return offset;
 	}


### PR DESCRIPTION
Verified against replays, this is the real deal.

There is one more thing that needs to be done in the future for object culling to look exactly like authentic, so I left a comment in the code. For now it will do because it does show what the server can "see" (the missing functionality is just client-side that doesn't effect anything really). I will probably get around to fixing it soon.

[Video](https://www.youtube.com/watch?v=Os9Bs0yPPPI)

This also allows view distance to be set up to 2x (value of 4 in the config) with proper client support.