### PR TITLE
Firemaking Success Formula

### DIFF
--- a/server/src/com/openrsc/server/util/rsc/Formulae.java
+++ b/server/src/com/openrsc/server/util/rsc/Formulae.java
@@ -809,7 +809,7 @@ public final class Formulae {
 	 * Should the fire light or fail?
 	 */
 	public static boolean lightLogs(int firemakingLvl) {
-		int chance = (int)(29 * ( Math.pow(firemakingLvl, (2 / 9))) + 20);
+		int chance = (int)(35 * Math.pow(firemakingLvl, (1 / 4)));
 		return chance > DataConversions.random(0, 100);
 	}
 


### PR DESCRIPTION
Previously failure was possible up until level 99. Now failure rates drop off differently, and end around level 65.