### PR TITLE
Fixes Dialogue Menu Closing Bug

### DIFF
--- a/server/src/com/openrsc/server/model/entity/player/Player.java
+++ b/server/src/com/openrsc/server/model/entity/player/Player.java
@@ -1288,8 +1288,8 @@ public final class Player extends Mob {
 	}
 
 	public void message(String string) {
-		resetMenuHandler();
-		setOption(-1);
+		// resetMenuHandler();
+		// setOption(-1);
 		ActionSender.sendMessage(this, string);
 	}
 


### PR DESCRIPTION
Comment out two lines, responsible for closing dialogue menus when the player is sent a system message (white text normally related to actions or the game telling the player something). I don't see why this dialogue was being closed when the player was sent a message, but I'm sure there may be some explanation.

#672 