### PR TITLE
NPC Grammar and Dialog Menu Fixes

### DIFF
--- a/server/plugins/com/openrsc/server/plugins/npcs/lumbridge/Priest.java
+++ b/server/plugins/com/openrsc/server/plugins/npcs/lumbridge/Priest.java
@@ -14,6 +14,7 @@ public class Priest implements TalkToNpcExecutiveListener, TalkToNpcListener {
 
 	@Override
 	public void onTalkToNpc(final Player p, final Npc n) {// that could work
+		npcTalk(p, n, "Welcome to the church of holy Saradomin");
 		if (p.getQuestStage(Quests.THE_RESTLESS_GHOST) == 1) {
 			playerTalk(p, n, "I can't find father Urhney at the moment");
 			npcTalk(p,

--- a/server/plugins/com/openrsc/server/plugins/npcs/lumbridge/Priest.java
+++ b/server/plugins/com/openrsc/server/plugins/npcs/lumbridge/Priest.java
@@ -73,7 +73,7 @@ public class Priest implements TalkToNpcExecutiveListener, TalkToNpcListener {
 					@Override
 					public void action() {
 						npcTalk(p, n, "That's strange",
-								"I tought things not from this world were all slime and tenticles");
+								"I thought things not from this world were all slime and tenticles");
 						new Menu()
 								.addOptions(
 										new Option(

--- a/server/plugins/com/openrsc/server/plugins/npcs/lumbridge/Priest.java
+++ b/server/plugins/com/openrsc/server/plugins/npcs/lumbridge/Priest.java
@@ -58,9 +58,9 @@ public class Priest implements TalkToNpcExecutiveListener, TalkToNpcListener {
 			public void action() {
 				npcTalk(p,
 						n,
-						"Surely you have heard of the God Saradomin?",
+						"Surely you have heard of the God, Saradomin?",
 						"He who creates the forces of goodness and purity in this world?",
-						"I cannot belive your ignorance!",
+						"I cannot believe your ignorance!",
 						"This is the God with more followers than any other!",
 						"At least in theses parts!",
 						"He who along with his brothers Guthix and Zamorak created this world");

--- a/server/plugins/com/openrsc/server/plugins/npcs/lumbridge/Urhney.java
+++ b/server/plugins/com/openrsc/server/plugins/npcs/lumbridge/Urhney.java
@@ -117,18 +117,15 @@ public class Urhney implements TalkToNpcExecutiveListener, TalkToNpcListener {
 				new Menu().addOptions(new Option("Repeated failure on mortgage payments") {
 					@Override
 					public void action() {
-						npcTalk(p, n, "I don't have a mortgage",
-								"I built this house myself");
-						playerTalk(p, n,
-								"Sorry I must have got the wrong address",
-								"All the houses look the same around here");
+						npcTalk(p, n, "I don't have a mortgage", "I built this house myself");
+						playerTalk(p, n, "Sorry I must have got the wrong address", "All the houses look the same around here");
 					}
 				}, new Option("I don't know, I just wanted this house") {
 					@Override
 					public void action() {
 						npcTalk(p, n, "Oh go away and stop wasting my time");
 					}
-				});
+				}).showMenu(p);
 			}
 		});
 		defaultMenu.showMenu(p);

--- a/server/plugins/com/openrsc/server/plugins/npcs/lumbridge/Urhney.java
+++ b/server/plugins/com/openrsc/server/plugins/npcs/lumbridge/Urhney.java
@@ -114,8 +114,7 @@ public class Urhney implements TalkToNpcExecutiveListener, TalkToNpcListener {
 			@Override
 			public void action() {
 				npcTalk(p, n, "Under what grounds?");
-				new Menu().addOptions(new Option(
-						"Repeated failure on mortgage payments") {
+				new Menu().addOptions(new Option("Repeated failure on mortgage payments") {
 					@Override
 					public void action() {
 						npcTalk(p, n, "I don't have a mortgage",


### PR DESCRIPTION
Was validating the Restless Ghost and fixed grammar issues. Also fixed one issue where an entire menu of dialog opens where not shown to the player when speaking to Father Urhney.