### PR TITLE
Fixed ::onlinelist Multiple Popup Boxes

### DIFF
--- a/server/plugins/com/openrsc/server/plugins/commands/RegularPlayer.java
+++ b/server/plugins/com/openrsc/server/plugins/commands/RegularPlayer.java
@@ -235,9 +235,8 @@ public final class RegularPlayer implements CommandListener {
 			return;
 		}
 		if (command.equals("onlinelist")) {
-			List<Player> onlinePlayers = ActionSender.sendOnlineList(player);
 			String boxTextPlayerNames = "";
-			for(Player p : onlinePlayers) {
+			for(Player p : World.getWorld().getPlayers()) {
 				boxTextPlayerNames += p.getUsername() + "%";
 			}
 			ActionSender.sendBox(player, "" + "@yel@Online Players: %" + boxTextPlayerNames,true);

--- a/server/src/com/openrsc/server/net/rsc/ActionSender.java
+++ b/server/src/com/openrsc/server/net/rsc/ActionSender.java
@@ -1094,18 +1094,15 @@ public class ActionSender {
 		}
 	}
 
-	public static List<Player> sendOnlineList(Player player) {
-		List<Player> onlinePlayers = new ArrayList<Player>();
+	public static void sendOnlineList(Player player) {
 		PacketBuilder pb = new PacketBuilder(134);
 		pb.writeByte(5);
 		pb.writeShort(World.getWorld().getPlayers().size());
 		for (Player p : World.getWorld().getPlayers()) {
 			pb.writeString(p.getUsername());
 			pb.writeByte(p.getIcon());
-			onlinePlayers.add(p);
 		}
 		player.write(pb.toPacket());
-		return onlinePlayers;
 	}
 
 	public static void showFishingTrawlerInterface(Player p) {


### PR DESCRIPTION
Before, I was sending 2 packets, one with player list and one with a box which read and rendered the playerlist. The problem is that both packets contained data which would render popup boxes when interpreted by client.

I now do the calculation before sending a single packet which renders the desired box.