### PR TITLE
Dwarven Stout Missing Dialog and Player Message Timing

### DIFF
--- a/server/plugins/com/openrsc/server/plugins/itemactions/Drinkables.java
+++ b/server/plugins/com/openrsc/server/plugins/itemactions/Drinkables.java
@@ -269,7 +269,6 @@ public class Drinkables implements InvActionListener, InvActionExecutiveListener
 			if (player.getSkills().getLevel(14) <= player.getSkills().getMaxStat(14)) {
 				player.getSkills().setLevel(14, player.getSkills().getLevel(14) + 1);
 			}
-
 			break;
 		case 267: // Asgarnian Ale
 			player.message("You drink the " + item.getDef().getName() + ".");

--- a/server/plugins/com/openrsc/server/plugins/itemactions/Drinkables.java
+++ b/server/plugins/com/openrsc/server/plugins/itemactions/Drinkables.java
@@ -255,10 +255,11 @@ public class Drinkables implements InvActionListener, InvActionExecutiveListener
 		case 269: // Dwarven Stout
 			showBubble(player, item);
 			player.message("You drink the " + item.getDef().getName() + ".");
+			player.message("It tastes foul.");
 			player.getInventory().remove(item);
 			player.getInventory().add(new Item(620));
-			sleep(1200);
-			player.message("It tastes foul.");
+			sleep(1600);
+			player.message("It tastes pretty strong too");
 			for (int stat = 0; stat < 3; stat++) {
 				player.getSkills().setLevel(stat, player.getSkills().getLevel(stat) - 4);
 			}
@@ -268,6 +269,7 @@ public class Drinkables implements InvActionListener, InvActionExecutiveListener
 			if (player.getSkills().getLevel(14) <= player.getSkills().getMaxStat(14)) {
 				player.getSkills().setLevel(14, player.getSkills().getLevel(14) + 1);
 			}
+
 			break;
 		case 267: // Asgarnian Ale
 			player.message("You drink the " + item.getDef().getName() + ".");


### PR DESCRIPTION
Added authentic missing line of dialog. Added proper message delay for the third line of dialog.

Interesting note: #1207 states that combat stats are deducted but mining and smithing are never buffed... This is not true. The single level buff is definitely given and I recommend someone else confirm along with me and close the issue. Trust me I drank like 50 of them to mimic message delay in sync with the replay.