### PR TITLE
Path Map Around Walls Properly.

### DIFF
--- a/server/src/com/openrsc/server/model/PathValidation.java
+++ b/server/src/com/openrsc/server/model/PathValidation.java
@@ -7,7 +7,7 @@ import java.util.Deque;
 import java.util.LinkedList;
 
 /**
- * 
+ *
  * @author Graham
  *
  */
@@ -81,7 +81,7 @@ public class PathValidation {
 			} else if (coords[1] < startY) {
 				newYBlocked = isBlocking(coords[0], coords[1], 4);
 			}
-			
+
 			if ((newXBlocked && newYBlocked)
 					|| (newXBlocked && startY == coords[1])
 					|| (myYBlocked && startX == coords[0])) {
@@ -95,16 +95,16 @@ public class PathValidation {
 		}
 		return true;
 	}
-	
-	private static boolean isBlocking(int x, int y, int bit) {
+
+	public static boolean isBlocking(int x, int y, int bit) {
 		TileValue t = World.getWorld().getTile(x, y);
 		if(t.projectileAllowed) {
 			return false;
 		}
-		
+
 		return isBlocking(t.traversalMask, (byte) bit);
 	}
-	
+
 	private static boolean isBlocking(int objectValue, byte bit) {
 		if ((objectValue & bit) != 0) { // There is a wall in the way
 			return true;

--- a/server/src/com/openrsc/server/model/action/WalkToMobAction.java
+++ b/server/src/com/openrsc/server/model/action/WalkToMobAction.java
@@ -1,10 +1,11 @@
 package com.openrsc.server.model.action;
 
+import com.openrsc.server.model.PathValidation;
 import com.openrsc.server.model.entity.Mob;
 import com.openrsc.server.model.entity.player.Player;
 
 public abstract class WalkToMobAction extends WalkToAction {
-	
+
 	private int radius;
 	protected Mob mob;
 
@@ -23,6 +24,10 @@ public abstract class WalkToMobAction extends WalkToAction {
 	}
 	@Override
 	public boolean shouldExecute() {
-		return (player.withinRange(mob, radius) && !hasExecuted);
+		return (player.withinRange(mob, radius)
+			&& !PathValidation.isBlocking(
+				player.getX() + (player.getX() - mob.getX()),
+				player.getY() + (player.getY() - mob.getY()), 15)
+			&& !hasExecuted);
 	}
 }


### PR DESCRIPTION
Add a check to ensure the player knows whether the player character
knows that walls might be in the way of their path, when directly beside
an npc they are attempting to interact with. This might make path
mapping slightly inauthentic, as it may not "cut corners" as frequently
as it used to.