### PR TITLE
Fix in gem mining able to prospect, swings and empty rock

### DIFF
--- a/server/plugins/com/openrsc/server/plugins/skills/GemMining.java
+++ b/server/plugins/com/openrsc/server/plugins/skills/GemMining.java
@@ -1,6 +1,8 @@
 package com.openrsc.server.plugins.skills;
 
 import com.openrsc.server.event.custom.BatchEvent;
+import com.openrsc.server.external.EntityHandler;
+import com.openrsc.server.external.ObjectMiningDef;
 import com.openrsc.server.model.container.Item;
 import com.openrsc.server.model.entity.GameObject;
 import com.openrsc.server.model.entity.player.Player;
@@ -12,6 +14,7 @@ import com.openrsc.server.util.rsc.Formulae;
 
 import static com.openrsc.server.plugins.Functions.message;
 import static com.openrsc.server.plugins.Functions.showBubble;
+import static com.openrsc.server.plugins.Functions.sleep;
 
 public class GemMining implements ObjectActionListener,
 ObjectActionExecutiveListener {
@@ -33,6 +36,7 @@ ObjectActionExecutiveListener {
 		if (!p.withinRange(obj, 1)) {
 			return;
 		}
+		final ObjectMiningDef def = EntityHandler.getObjectMiningDef(obj.getID());
 		final int axeId = getAxe(p);
 		int retrytimes = -1;
 		final int mineLvl = p.getSkills().getLevel(14);
@@ -45,11 +49,11 @@ ObjectActionExecutiveListener {
 			retrytimes = 2;
 			break;
 		case 1259:
-			retrytimes = 4;
+			retrytimes = 3;
 			reqlvl = 6;
 			break;
 		case 1260:
-			retrytimes = 6;
+			retrytimes = 5;
 			reqlvl = 21;
 			break;
 		case 1261:
@@ -60,6 +64,22 @@ ObjectActionExecutiveListener {
 			retrytimes = 12;
 			reqlvl = 41;
 			break;
+		}
+		
+		if (p.click == 1) {
+			p.playSound("prospect");
+			p.setBusyTimer(1800);
+			p.message("You examine the rock for ores...");
+			sleep(1800);
+			if (obj.getID() == GEM_ROCK) {
+				p.message("You fail to find anything interesting");
+				return;
+			}
+			//should not get into the else, just a fail-safe
+			else {
+				p.message("There is currently no ore available in this rock");
+				return;
+			}
 		}
 
 		if (axeId < 0 || reqlvl > mineLvl) {
@@ -110,7 +130,7 @@ ObjectActionExecutiveListener {
 
 	@Override
 	public boolean blockObjectAction(GameObject obj, String command, Player p) {
-		if(obj.getID() == GEM_ROCK && command.equals("mine")) {
+		if(obj.getID() == GEM_ROCK && (command.equals("mine") || command.equals("prospect"))) {
 			return true;
 		}
 		return false;
@@ -118,7 +138,7 @@ ObjectActionExecutiveListener {
 
 	@Override
 	public void onObjectAction(GameObject obj, String command, Player p) {
-		if(obj.getID() == GEM_ROCK && command.equals("mine")) {
+		if(obj.getID() == GEM_ROCK && (command.equals("mine") || command.equals("prospect"))) {
 			handleGemRockMining(obj, p, p.click);
 		}
 	}

--- a/server/plugins/com/openrsc/server/plugins/skills/Mining.java
+++ b/server/plugins/com/openrsc/server/plugins/skills/Mining.java
@@ -133,11 +133,11 @@ ObjectActionExecutiveListener {
 			retrytimes = 2;
 			break;
 		case 1259:
-			retrytimes = 4;
+			retrytimes = 3;
 			reqlvl = 6;
 			break;
 		case 1260:
-			retrytimes = 6;
+			retrytimes = 5;
 			reqlvl = 21;
 			break;
 		case 1261:
@@ -150,12 +150,7 @@ ObjectActionExecutiveListener {
 			break;
 		}
 
-		if (object.getID() == 98) {
-			owner.message("Nothing interesting happens");
-			return;
-		}
-
-		if (def == null || def.getRespawnTime() < 1 || (def.getOreId() == 315 && owner.getQuestStage(Quests.FAMILY_CREST) < 6)) {
+		if (owner.click == 0 && (def == null || def.getRespawnTime() < 1 || (def.getOreId() == 315 && owner.getQuestStage(Quests.FAMILY_CREST) < 6))) {
 			if (axeId < 0 || reqlvl > mineLvl) {
 				message(owner, "You need a pickaxe to mine this rock",
 						"You do not have a pickaxe which you have the mining level to use");


### PR DESCRIPTION
- Fixes #1399 
- Corrected swings for steel and mith pickaxes (for steel taken from rsc+ replay, mith from https://youtu.be/3auraN8F4kY?t=299)
- Also gem rocks have prospect as in authentic!