### PR TITLE
Fix several missing shilo village behavior dialogue and stuff

### DIFF
--- a/server/plugins/com/openrsc/server/plugins/npcs/shilo/Yanni.java
+++ b/server/plugins/com/openrsc/server/plugins/npcs/shilo/Yanni.java
@@ -24,43 +24,60 @@ public class Yanni implements TalkToNpcListener, TalkToNpcExecutiveListener, Inv
 
 	@Override
 	public void onTalkToNpc(Player p, Npc n) {
+		boolean hasItemsInterest = false;
 		if (n.getID() == YANNI) {
 			playerTalk(p, n, "Hello there!");
 			npcTalk(p, n, "Greetings Bwana!",
-				"My name is Yanni and I buy and sell antiques ",
-				"and other interesting items.",
-				"If you have any interesting items that you might",
-				"want to sell me, please let me see them and I'll",
-				"offer you a fair price.",
-				"Would you like me to have a look at your items",
-				"and give you a quote?");
+					"My name is Yanni and I buy and sell antiques ",
+					"and other interesting items.",
+					"If you have any interesting items that you might",
+					"want to sell me, please let me see them and I'll",
+					"offer you a fair price.",
+					"Would you like me to have a look at your items",
+					"and give you a quote?");
 			int menu = showMenu(p, n,
-				"Yes please!",
-				"Maybe some other time?");
+					"Yes please!",
+					"Maybe some other time?");
 			if (menu == 0) {
 				npcTalk(p, n, "Great Bwana!");
+				if (hasItem(p, 835)) {
+					npcTalk(p, n, "I'll give you 100 Gold for the Bone Key.");
+					hasItemsInterest |= true;
+				}
+				if (hasItem(p, 958)) {
+					npcTalk(p, n, "I'll give you 100 Gold for the Stone-Plaque.");
+					hasItemsInterest |= true;
+				}
 				if (hasItem(p, 959)) {
 					npcTalk(p, n, "I'll give you 100 Gold for your tattered scroll");
+					hasItemsInterest |= true;
 				}
 				if (hasItem(p, 960)) {
 					npcTalk(p, n, "I'll give you 100 Gold for your crumpled scroll");
+					hasItemsInterest |= true;
 				}
 				if (hasItem(p, 961)) {
 					npcTalk(p, n, "I'll give you 100 Gold for your Bervirius Tomb Notes.");
+					hasItemsInterest |= true;
+				}
+				if (hasItem(p, 972)) {
+					npcTalk(p, n, "WOW! I'll give you 500 Gold for your Locating Crystal!");
+					hasItemsInterest |= true;
 				}
 				if (hasItem(p, 852)) {
 					npcTalk(p, n, "Great I'll give you 1000 Gold for your Beads of the Dead.");
+					hasItemsInterest |= true;
 				}
-				if (hasItem(p, 959) || hasItem(p, 960) || hasItem(p, 961) || hasItem(p, 852)) {
+				if (hasItemsInterest) {
 					npcTalk(p, n, "Those are the items I am interested in Bwana.",
-						"If you want to sell me those items, simply show them to me.");
+							"If you want to sell me those items, simply show them to me.");
 				} else {
 					npcTalk(p, n, "Sorry Bwana, you have nothing I am interested in.");
 				}
 
 			} else if (menu == 1) {
 				npcTalk(p, n, "Sure thing.",
-					"Have a nice day Bwana.");
+						"Have a nice day Bwana.");
 			}
 		}
 	}
@@ -77,39 +94,51 @@ public class Yanni implements TalkToNpcListener, TalkToNpcExecutiveListener, Inv
 	public void onInvUseOnNpc(Player p, Npc npc, Item item) {
 		if (npc.getID() == YANNI) {
 			switch (item.getID()) {
-				case 972:
-					npcTalk(p, npc, "Great item, here's 500 Gold for it.");
-					removeItem(p, 972, 1);
-					addItem(p, 10, 500);
-					p.message("You sell the Locating Crystal.");
-					break;
-				case 959:
-					npcTalk(p, npc, "Great item, here's 100 Gold for it.");
-					removeItem(p, 959, 1);
-					addItem(p, 10, 100);
-					p.message("You sell the Tattered Scroll.");
-					break;
-				case 960:
-					npcTalk(p, npc, "Great item, here's 100 Gold for it.");
-					removeItem(p, 960, 1);
-					addItem(p, 10, 100);
-					p.message("You sell the crumpled Scroll.");
-					break;
-				case 961:
-					npcTalk(p, npc, "Great item, here's 100 Gold for it.");
-					removeItem(p, 961, 1);
-					addItem(p, 10, 100);
-					p.message("You sell the Bervirius Tomb Notes.");
-					break;
-				case 852:
-					npcTalk(p, npc, "Great item, here's 1000 Gold for it.");
-					removeItem(p, 852, 1);
-					addItem(p, 10, 1000);
-					p.message("You sell Beads of the Dead.");
-					break;
-				default:
-					p.message("Nothing interesting happens");
-					break;
+			case 835:
+				npcTalk(p, npc, "Great item, here's 100 Gold for it.");
+				removeItem(p, 835, 1);
+				addItem(p, 10, 100);
+				p.message("You sell the Bone Key.");
+				break;
+			case 958:
+				npcTalk(p, npc, "Great item, here's 100 Gold for it.");
+				removeItem(p, 958, 1);
+				addItem(p, 10, 100);
+				p.message("You sell the Stone Plaque.");
+				break;
+			case 959:
+				npcTalk(p, npc, "Great item, here's 100 Gold for it.");
+				removeItem(p, 959, 1);
+				addItem(p, 10, 100);
+				p.message("You sell the Tattered Scroll.");
+				break;
+			case 960:
+				npcTalk(p, npc, "Great item, here's 100 Gold for it.");
+				removeItem(p, 960, 1);
+				addItem(p, 10, 100);
+				p.message("You sell the crumpled Scroll.");
+				break;
+			case 961:
+				npcTalk(p, npc, "Great item, here's 100 Gold for it.");
+				removeItem(p, 961, 1);
+				addItem(p, 10, 100);
+				p.message("You sell the Bervirius Tomb Notes.");
+				break;
+			case 972:
+				npcTalk(p, npc, "Great item, here's 500 Gold for it.");
+				removeItem(p, 972, 1);
+				addItem(p, 10, 500);
+				p.message("You sell the Locating Crystal.");
+				break;
+			case 852:
+				npcTalk(p, npc, "Great item, here's 1000 Gold for it.");
+				removeItem(p, 852, 1);
+				addItem(p, 10, 1000);
+				p.message("You sell Beads of the Dead.");
+				break;
+			default:
+				p.message("Nothing interesting happens");
+				break;
 			}
 		}
 	}

--- a/server/plugins/com/openrsc/server/plugins/quests/members/Jungle_Potion.java
+++ b/server/plugins/com/openrsc/server/plugins/quests/members/Jungle_Potion.java
@@ -542,19 +542,20 @@ public class Jungle_Potion implements QuestInterface, ObjectActionListener,
 								"Yes, I've found Rashiliyia's Tomb!",
 								"I get choked when I go into Rashiliyias Tomb.");
 							if (tomb == 0) {
-								playerTalk(p, n, "Nope, I haven't found anything.");
 								npcTalk(p, n, "Well, that is a pity? Perhaps you should keep on looking?");
 							} else if (tomb == 1) {
 								npcTalk(p, n, "Very good Bwana, this is very good!",
 									"Did you find her remains?");
-								int newMenu = showMenu(p, n,
+								int newMenu = showMenu(p, n, false, //do not send over
 									"Yes, In fact I did!",
 									"Nope, I haven't found them yet.");
 								if (newMenu == 0) {
+									playerTalk(p, n, "Yes, In fact I did!");
 									npcTalk(p, n, "This is truly great Bwana.",
 										"If you need help with the remains, ",
 										"please show them to me.");
 								} else if (newMenu == 1) {
+									playerTalk(p, n, "No, I haven't found them yet.");
 									npcTalk(p, n, "You really need to find the remains before we",
 										"can hope to defeat her and remove her influence from",
 										"Shilo village.");
@@ -617,21 +618,26 @@ public class Jungle_Potion implements QuestInterface, ObjectActionListener,
 				npcTalk(p, n, "If you have found the temple, you should search it",
 					"thoroughly and see if there are any clues about",
 					"Rashiliyia.");
-				int ex3 = showMenu(p, n,
+				int ex3 = showMenu(p, n, false, //do not send over
 					"I need help with Rashlilia.",
 					"I need help with Zadimus.",
 					"I have some items that I need help with.",
 					"I need help with Bervirius.",
 					"Ok, thanks!");
 				if (ex3 == 0) {
+					playerTalk(p, n, "I need help with Rashliyia.");
 					trufitisChat(p, n, Trufitus.HELP_WITH_RASH);
 				} else if (ex3 == 1) {
+					playerTalk(p, n, "I need help with Zadimus.");
 					trufitisChat(p, n, Trufitus.HELP_WITH_ZADIMUS);
 				} else if (ex3 == 2) {
+					playerTalk(p, n, "I have some items that I need help with.");
 					trufitisChat(p, n, Trufitus.SHOW_ME_TEMPLE_ITEMS);
 				} else if (ex3 == 3) {
+					playerTalk(p, n, "I need help with Bervirius.");
 					trufitisChat(p, n, Trufitus.HELP_WITH_BERVIRIUS);
 				} else if (ex3 == 4) {
+					playerTalk(p, n, "Ok, thanks!");
 					npcTalk(p, n, "You're quite welcome Bwana.");
 				}
 				break;
@@ -682,21 +688,26 @@ public class Jungle_Potion implements QuestInterface, ObjectActionListener,
 				break;
 			case Trufitus.ACTUALLY_NEED_HELP_WITH_SOMETHING_ELSE:
 				npcTalk(p, n, "What could I possibly help you with Bwana?");
-				int c = showMenu(p, n,
+				int c = showMenu(p, n, false, //do not send over
 					"I need help with Rashiliyia.",
 					"I need help with Zadimus.",
 					"I have some items that I need help with.",
 					"I need help with Bervirius.",
 					"Ok, thanks!");
 				if (c == 0) {
+					playerTalk(p, n, "I need help with Rashliyia.");
 					trufitisChat(p, n, Trufitus.HELP_WITH_RASH);
 				} else if (c == 1) {
+					playerTalk(p, n, "I need help with Zadimus.");
 					trufitisChat(p, n, Trufitus.HELP_WITH_ZADIMUS);
 				} else if (c == 2) {
+					playerTalk(p, n, "I have some items that I need help with.");
 					trufitisChat(p, n, Trufitus.SHOW_ME_TEMPLE_ITEMS);
 				} else if (c == 3) {
+					playerTalk(p, n, "I need help with Bervirius.");
 					trufitisChat(p, n, Trufitus.HELP_WITH_BERVIRIUS);
 				} else if (c == 4) {
+					playerTalk(p, n, "Ok, thanks!");
 					npcTalk(p, n, "You're quite welcome Bwana.");
 				}
 				break;
@@ -889,14 +900,48 @@ public class Jungle_Potion implements QuestInterface, ObjectActionListener,
 				}
 				break;
 			case Trufitus.SHOW_ME_TEMPLE_ITEMS:
-				npcTalk(p, n, "Look for something that can identify the place.",
-					"Leave no stone unturned.",
-					"Any scrolls or information about Rashiliyias Kin would be helpful",
-					"Have you got any items concerning Rashiliyia?",
-					"If so, please show me them.",
-					"There must be something relating to Zadimus at the temple",
-					"Did you find anything? If so, let me see it.",
-					"And best of luck!");
+				npcTalk(p, n, "Well, just let me see the item and I'll help as much as I can.");
+				if (p.getQuestStage(Constants.Quests.SHILO_VILLAGE) >= 6) {
+					int optTemp = showMenu(p, n, "I need help with Zadimus.",
+							"I need help with Bervirius.",
+							"I need help with Rashliyia.",
+							"I need some help with the Temple of Ah Za Rhoon.",
+							"Ok, thanks!");
+					if (optTemp == 0) {
+						trufitisChat(p, n, Trufitus.HELP_WITH_BERVIRIUS);
+					} else if (optTemp == 1) {
+						trufitisChat(p, n, Trufitus.HELP_WITH_RASH);
+					} else if (optTemp == 2) {
+						trufitisChat(p, n, Trufitus.HELP_WITH_AH_ZA_RHOON_TEMPLE);
+					} else if (optTemp == 3) {
+						npcTalk(p, n, "You're quite welcome Bwana.");
+					}
+					return;
+				}
+				//no stone-plaque in bank or inventory
+				if(!p.getBank().hasItemId(958) && !p.getInventory().hasItemId(958)) {
+					npcTalk(p, n, "Look for something that can identify the place.",
+							"Leave no stone unturned.");
+				}
+				else {
+					npcTalk(p, n, "We need to identify that the place you have found",
+							"is indeed Ah Za Rhoon.");
+				}
+				//player has not explored inner Ah Za Rhoon
+				if(!p.getCache().hasKey("obtained_shilo_info")) {
+					npcTalk(p, n, "Look for details of Rashiliyias Kin, these may be well hidden.",
+							"There is a legend about Rashiliyia, look for it in the temple.",
+							"Look for something relating to Zadimus at the temple.",
+							"And best of luck!");
+				}
+				else {
+					npcTalk(p, n, "Any scrolls or information about Rashiliyias Kin would be helpful",
+							"Have you got any items concerning Rashiliyia?",
+							"If so, please show me them.",
+							"There must be something relating to Zadimus at the temple",
+							"Did you find anything? If so, let me see it.",
+							"And best of luck!");
+				}
 				break;
 			case Trufitus.KEYS_AND_KIN:
 				npcTalk(p, n, "Hmmm, maybe it's a clue of some kind?",

--- a/server/plugins/com/openrsc/server/plugins/quests/members/shilovillage/ShiloVillageMosolRei.java
+++ b/server/plugins/com/openrsc/server/plugins/quests/members/shilovillage/ShiloVillageMosolRei.java
@@ -151,7 +151,7 @@ public class ShiloVillageMosolRei implements TalkToNpcListener, TalkToNpcExecuti
 									if (sub_opt3 == 0) {
 										moselReiDialogue(p, n, MoselRei.SOMEONE_WHO_DOES_KNOW);
 									} else if (sub_opt3 == 1) {
-										npcTalk(p, n, "Ok, I understand, you may as well be on your way then.");
+										npcTalk(p, n, "Ok, perhaps you'd like to be on your way now?");
 									}
 								} else if (sub_opt2 == 2) {
 									moselReiDialogue(p, n, MoselRei.SOMEONE_WHO_DOES_KNOW);
@@ -161,9 +161,6 @@ public class ShiloVillageMosolRei implements TalkToNpcListener, TalkToNpcExecuti
 							}
 						} else if (option == 1) {
 							moselReiDialogue(p, n, MoselRei.WHAT_CAN_WE_DO);
-							npcTalk(p, n, "But you would need to speak to the Witch Doctor in the Tai Bwo Wannai village.",
-								"To get more details about that.",
-								"I really have to go now and fight these undead!");
 						}
 						break;
 				}
@@ -178,7 +175,10 @@ public class ShiloVillageMosolRei implements TalkToNpcListener, TalkToNpcExecuti
 						"The village is covered in a deadly green mist.",
 						"If you go into the village, a terrible sickness will befall you.",
 						"And the undead creatures are even stonger beyond the gates.",
-						"My guess is that it has something to do with the legend of Rashiliyia.");
+						"My guess is that it has something to do with the legend of Rashiliyia.",
+						"But you would need to speak to the Witch Doctor in the Tai Bwo Wannai village.",
+						"To get more details about that.",
+						"I really have to go now and fight these undead!");
 					break;
 				case MoselRei.SOMEONE_WHO_DOES_KNOW:
 					npcTalk(p, n, "My guess is that this has something to do with the legend of Rashiliyia.",

--- a/server/plugins/com/openrsc/server/plugins/quests/members/shilovillage/ShiloVillageNazastarool.java
+++ b/server/plugins/com/openrsc/server/plugins/quests/members/shilovillage/ShiloVillageNazastarool.java
@@ -103,7 +103,7 @@ public class ShiloVillageNazastarool implements ObjectActionListener, ObjectActi
 				"Do not return here or your life will be forfeit!");
 		} else if (n.getID() == Nazastarool_Skeleton) {
 			npcTalk(p, n, "Leave now mortal, sweet Rashiliyia will rest!",
-				"Your life will be forfet if you return!");
+				"Your life will be forfeit if you return!");
 		} else if (n.getID() == Nazastarool_Ghost) {
 			npcTalk(p, n, "Run infidel and never polute the tomb of Rashiliyia again!",
 				"A grisly death is what you will meet should you return.");
@@ -165,11 +165,11 @@ public class ShiloVillageNazastarool implements ObjectActionListener, ObjectActi
 			if (!p.getCache().hasKey("dolmen_zombie")) {
 				p.getCache().store("dolmen_zombie", true);
 			}
-			p.message("You defeat Nazastarool and the corpse falls to");
+			p.message("You defeat Nazastarool and the corpse falls to  ");
 			sleep(1200);
-			p.message("the ground. The bones start to move again and");
+			p.message("the ground. The bones start to move again and   ");
 			sleep(1200);
-			p.message("soon they reform into a grisly giant skeleton.");
+			p.message("soon they reform into a grisly giant skeleton.  ");
 			sleep(1000);
 			spawnAndMoveAway(p, Nazastarool_Skeleton);
 			p.setBusy(false);
@@ -180,11 +180,11 @@ public class ShiloVillageNazastarool implements ObjectActionListener, ObjectActi
 			if (!p.getCache().hasKey("dolmen_skeleton")) {
 				p.getCache().store("dolmen_skeleton", true);
 			}
-			p.message("You defeat the Nazastarool Skeleton as the corpse falls to");
+			p.message("You defeat the Nazastarool Skeleton as the corpse falls to ");
 			sleep(1200);
-			p.message("the ground. An ethereal form starts taking shape above the");
+			p.message("the ground. An ethereal form starts taking shape above the ");
 			sleep(1200);
-			p.message("bones and you soon face the vengeful ghost of Nazastarool");
+			p.message("bones and you soon face the vengeful ghost of Nazastarool ");
 			sleep(1000);
 			spawnAndMoveAway(p, Nazastarool_Ghost);
 			p.setBusy(false);

--- a/server/plugins/com/openrsc/server/plugins/quests/members/shilovillage/ShiloVillageTombDolmen.java
+++ b/server/plugins/com/openrsc/server/plugins/quests/members/shilovillage/ShiloVillageTombDolmen.java
@@ -36,6 +36,9 @@ public class ShiloVillageTombDolmen implements QuestInterface, ObjectActionListe
 	@Override
 	public void handleReward(Player player) {
 		/* REMOVE CACHES AFTER QUEST COMPLETE THAT NO LONGER IS USED */
+		if (player.getCache().hasKey("obtained_shilo_info")) {
+			player.getCache().remove("obtained_shilo_info");
+		}
 		if (player.getCache().hasKey("coins_shilo_cave")) {
 			player.getCache().remove("coins_shilo_cave");
 		}
@@ -44,6 +47,12 @@ public class ShiloVillageTombDolmen implements QuestInterface, ObjectActionListe
 		}
 		if (player.getCache().hasKey("tomb_door_shilo")) {
 			player.getCache().remove("tomb_door_shilo");
+		}
+		if (player.getCache().hasKey("SV_DIG_LIT")) {
+			player.getCache().remove("SV_DIG_LIT");
+		}
+		if (player.getCache().hasKey("SV_DIG_ROPE")) {
+			player.getCache().remove("SV_DIG_ROPE");
 		}
 		if (player.getCache().hasKey("SV_DIG_BUMP")) {
 			player.getCache().remove("SV_DIG_BUMP");

--- a/server/plugins/com/openrsc/server/plugins/quests/members/shilovillage/ShiloVillageTrufitusInvUse.java
+++ b/server/plugins/com/openrsc/server/plugins/quests/members/shilovillage/ShiloVillageTrufitusInvUse.java
@@ -15,6 +15,9 @@ public class ShiloVillageTrufitusInvUse implements InvUseOnNpcListener, InvUseOn
 
 	@Override
 	public boolean blockInvUseOnNpc(Player p, Npc n, Item item) {
+		if (n.getID() == TRUFITUS && item.getID() == ShiloVillageObjects.STONE_PLAQUE) {
+			return true;
+		}
 		if (n.getID() == TRUFITUS && item.getID() == ShiloVillageObjects.CRUMPLED_SCROLL) {
 			return true;
 		}
@@ -24,19 +27,19 @@ public class ShiloVillageTrufitusInvUse implements InvUseOnNpcListener, InvUseOn
 		if (n.getID() == TRUFITUS && item.getID() == ShiloVillageObjects.ZADIMUS_CORPSE) {
 			return true;
 		}
-		if (n.getID() == TRUFITUS && item.getID() == 974) {
+		if (n.getID() == TRUFITUS && item.getID() == 974) { // bone shard
 			return true;
 		}
-		if (n.getID() == TRUFITUS && item.getID() == 972) {
+		if (n.getID() == TRUFITUS && item.getID() == 972) { // loc crystal
 			return true;
 		}
-		if (n.getID() == TRUFITUS && item.getID() == 961) {
+		if (n.getID() == TRUFITUS && item.getID() == 961) { // zadi corpse
 			return true;
 		}
-		if (n.getID() == TRUFITUS && item.getID() == 973) {
+		if (n.getID() == TRUFITUS && item.getID() == 973) { // sword pommel
 			return true;
 		}
-		if (n.getID() == TRUFITUS && item.getID() == 977) { // rash corpse.
+		if (n.getID() == TRUFITUS && item.getID() == 977) { // rash corpse
 			return true;
 		}
 		return false;
@@ -94,7 +97,7 @@ public class ShiloVillageTrufitusInvUse implements InvUseOnNpcListener, InvUseOn
 			"Something about kin and keys?");
 		int option2 = showMenu(p, n,
 			"How do I make a bronze necklace?",
-			"Thanks");
+			"Thanks!");
 		if (option2 == 0) {
 			bronzeNecklaceChat(p, n);
 		} else if (option2 == 1) {
@@ -263,8 +266,13 @@ public class ShiloVillageTrufitusInvUse implements InvUseOnNpcListener, InvUseOn
 				npcTalk(p, n, "Hmmm, well just that part about the wards..");
 				message(p, "Trufitus seems to drift off in thought.");
 				npcTalk(p, n, "It may be possible to make a ward like that?",
-					"But what is the best thing to make it from?",
-					"Perhaps you'll get some clues from other items?");
+					"But what is the best thing to make it from?");
+				// having zadimus corpse prolly
+				if(hasItem(p, ShiloVillageObjects.ZADIMUS_CORPSE)) {
+					npcTalk(p, n, "Now...what was it that Zadimus said...");
+				} else {
+					npcTalk(p, n, "Perhaps you'll get some clues from other items?");
+				}
 			} else if (menu == 1) {
 				npcTalk(p, n, "You're quite welcome Bwana.");
 			}
@@ -310,6 +318,26 @@ public class ShiloVillageTrufitusInvUse implements InvUseOnNpcListener, InvUseOn
 					"the spirit of this being may possess me and ",
 					"turn me into a minion of Rashiliyia.");
 			}
+		}
+		if (n.getID() == TRUFITUS && item.getID() == ShiloVillageObjects.STONE_PLAQUE) {
+			if (p.getQuestStage(Constants.Quests.SHILO_VILLAGE) == -1) {
+				playerTalk(p, n, "Have a look at this.");
+				npcTalk(p, n, "Hmmm, I'm not sure you will get much use out of this.",
+					"Why not see if you can sell it in Shilo Village.");
+				return;
+			}
+			p.message("You hand over the Stone Plaque to Trufitus.");
+			playerTalk(p, n, "Can you decipher this please?");
+			npcTalk(p, n, "This is an ancient artifact!");
+			p.message("Trufitus looks at the item in awe.");
+			npcTalk(p, n, "I can certainly try!",
+				"Hmm, incredible, it seems very ancient,",
+				"and mentions something about Zadimus and Ah Za Rhoon.",
+				"It says,'Here lies the traitor Zadimus, let his spirit",
+				"be forever tormented'");
+			p.message("Trufitus hands the Stone Plaque back");
+			npcTalk(p, n, "If you have found anything else that you need help with",
+					"please just let me know.");
 		}
 	}
 }


### PR DESCRIPTION
Primary fixes:
* Stone plaque and related behavior (obtaining, messages, dropping, etc)
* Corrected agility xp given on the specific shilo obstacles
* Going down bumpy dirt made safe if player attaches rope to it
* Fixed list of possible items able to be sold to Yannis and now they are sellable to him
* Added missing drop behavior with bone key